### PR TITLE
Fix for "network_interface.0.address" error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,4 +2,5 @@ provider "google" {
   credentials = "${file("./.secrets/account.json")}"
   region  = "${var.region}"
   project = "${var.project_id}"
+  version = "~>1.2"
 }

--- a/qse-install.tpl.ps1
+++ b/qse-install.tpl.ps1
@@ -52,6 +52,9 @@ $arguments = @("-silent -log ""${install_files_path}\qsefw-installation.log""", 
 Write-Host "Initiating silent Qlik Sense installation..."
 $arguments
 
+#VM needs more time
+Start-Sleep -Seconds 120
+
 Start-Process -FilePath "${install_files_path}\Qlik_Sense_setup.exe" -ArgumentList $arguments -NoNewWindow
 
 


### PR DESCRIPTION
Full error message as follows:
Error: google_compute_instance.qs-central-node: "network_interface.0.address": [REMOVED] Please use network_ip